### PR TITLE
Change default lifecycle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Provides an [EC2 Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_GetStarted.html)
 repository. In addition, it provides an optional default lifecycle
-policy that removes untagged images after 14 days, and retains only the 
-5 most recent images tagged with the prefix `git-`.
+policy.
+
 [Cross-account](https://aws.amazon.com/premiumsupport/knowledge-center/secondary-account-access-ecr/)
 access may also be enabled by setting the `readers` or `writers`
 arguments.

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -2,25 +2,90 @@
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Keep untagged images newer than 14 days",
+            "description": "Keep recent untagged images",
             "selection": {
                 "tagStatus": "untagged",
                 "countType": "sinceImagePushed",
                 "countUnit": "days",
-                "countNumber": 14
+                "countNumber": 7
             },
             "action": {
                 "type": "expire"
             }
         },
         {
-            "rulePriority": 2,
-            "description": "Keep up to five tagged images with prefix 'git-'",
+            "rulePriority": 10,
+            "description": "Keep images with 'develop' tag prefix",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["git-"],
+                "tagPrefixList": ["develop" ],
                 "countType": "imageCountMoreThan",
-                "countNumber": 5
+                "countNumber": 100000
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 11,
+            "description": "Keep images with 'latest' tag prefix",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["latest" ],
+                "countType": "imageCountMoreThan",
+                "countNumber": 100000
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 12,
+            "description": "Keep images with 'master' tag prefix",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["master" ],
+                "countType": "imageCountMoreThan",
+                "countNumber": 100000
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 13,
+            "description": "Keep images with 'prod' tag prefix",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["prod" ],
+                "countType": "imageCountMoreThan",
+                "countNumber": 100000
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 14,
+            "description": "Keep images with 'test' tag prefix",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["test" ],
+                "countType": "imageCountMoreThan",
+                "countNumber": 100000
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 100,
+            "description": "Keep other recent images",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 28
             },
             "action": {
                 "type": "expire"


### PR DESCRIPTION
Original lifecycle rules improperly deleted images that were tagged for deployment.
Due to annoying limitations in the capability of ECR lifecycle rules, we can't
have exactly what we want, but we reasonably approximate with these revised rules.