### PR TITLE
Support managing multiple ECR repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,60 @@
-.PHONY: all test clean docker sh shell
+.PHONY: all clean docker sh shell test tfc
 
 REPO := $(shell basename $(shell git remote get-url origin) .git)
 
-all: test
+GOPTS	:= -lR . -e
+GREP	:= grep $(GOPTS)
+EGREP	:= egrep $(GOPTS)
+SRCS	:= --include=*.tf
+DOCS	:= --include=README.md
 
-test: .terraform
+all: tfc test
+
+tfc: .terraform
+	@# Basic Terraform validation and formating checks
+	terraform version
 	AWS_DEFAULT_REGION=us-east-2 terraform validate
 	terraform fmt -check
-	! egrep "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" *.tf README.md
-	# Do NOT put terraform-aws in the title
+
+# Create .terraform if does not exist
+# A terraform init is requried to run a validate :-(
+.terraform:
+	terraform init -backend=false
+	terraform version
+
+test:
+	@####################################################
+	! $(EGREP) "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" $(SRCS) $(DOCS)
+	# Do NOT put terraform-aws in the title of the top-level README
 	! grep "#\s*terraform-aws-" README.md
 	# Do NOT use type string when you can use type number or bool!
-	! egrep '"\d+"|"true"|"false"' *.tf README.md
+	! $(EGREP) '"\d+"|"true"|"false"' $(SRCS) $(DOCS)
 	# Do NOT use old style maps in docs
-	! egrep "\w+\s*\{" README.md
+	! $(EGREP) "\w+\s*\{" $(DOCS)
 	# Do NOT drop the "s" in outputs.tf or variables.tf!
 	! find . -name output.tf -o -name variable.tf | grep '.*'
 	# Do NOT define an output in files other than outputs.tf
-	! egrep 'output\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name outputs.tf)
+	! $(EGREP) 'output\s+"\w+"\s*\{' $(SRCS) --exclude=outputs.tf
 	# Do NOT define a variable in files other than variables.tf
-	! egrep 'variable\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name variables.tf)
+	! $(EGREP) 'variable\s+"\w+"\s*\{' $(SRCS) --exclude=variables.tf
 	# DO put a badge in top-level README.md
 	grep -q "\[\!\[Terraform actions status\]([^)]*$(REPO)/workflows/terraform/badge.svg)\]([^)]*$(REPO)/actions)" README.md
+	# Do NOT split a source line over more than one line
+	! $(GREP) 'source\s*=\s*$$' $(SRCS) $(DOCS)
 	# Do NOT use ?ref= in source lines in a README.md!
-	! grep 'source\s*=.*?ref=' *.tf README.md
+	! $(GREP) 'source\s*=.*?ref=' $(DOCS)
 	# Do NOT start a source line with git::
-	! grep 'source\s*=\s*"git::' *.tf README.md
+	! $(GREP) 'source\s*=\s*"git::' $(SRCS) $(DOCS)
 	# Do NOT use .git in a source line
-	! grep 'source\s*=.*\.git.*"' *.tf README.md
+	! $(GREP) 'source\s*=.*\.git.*"' $(SRCS) $(DOCS)
+	# Do NOT use double slashes with top-level modules
+	! $(GREP) 'source\s*=.*//?ref=.*"' $(SRCS) $(DOCS)
+	# Do NOT leave extra whitespace at the end of a line
+	! $(EGREP) '\s+$$' $(SRCS)
+	# Do NOT leave empty lines at the start or end of a file
+	! find . -type f -name "*.tf" -exec sh -c "awk 'NR==1; END{print}' {} | egrep -q '^\s*$$' && echo {}" \; | grep '.*'
+	@# Run tflint if it is installed
+	@if which tflint >/dev/null; then tflint ; fi
 
 # Launches the Makefile inside a container
 docker: 
@@ -44,10 +71,4 @@ shell:
 
 clean:
 	-rm -rf .terraform
-	-docker rmi test/$(REPO)
-
-# Create .terraform if does not exist
-# A terraform init is requried to run a validate :-(
-.terraform:
-	terraform init -backend=false
-	terraform version
+	-docker rmi -f test/$(REPO) >/dev/null 2>&1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Example Usage
 module "foo" {
   source = "git@github.com:techservicesillinois/terraform-aws-ecr"
 
-  name = "repoName"
+  repos = [
+    "repo_name_1",
+    "repo_name_2",
+  ]
   writers = ["arn:aws:iam::874445906176:root"]
 }
 ```
@@ -25,25 +28,25 @@ Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) Name of the repository.
-
 * `disable_lifecycle_policy` - (Optional) If set to 'true', no lifecycle policy is applied. Default is 'false'.
 
 * `lifecycle_policy_path` – (Optional) Path to JSON document containing lifecycle policy.
 
 * `readers` - (Optional) List of account ARNs that can pull images.
 
-* `writers` - (Optional) List of account ARNs that can push images.
+* `repos` - (Required) List of repository names.
 
 * `tags` - (Optional) Map of tags for resources where supported.
+
+* `writers` - (Optional) List of account ARNs that can push images.
+
+### Debugging
+
+* `_debug` - (Optional) If set, produce verbose output for debugging.
 
 Attributes Reference
 --------------------
 
-The following attributes are exported:
+The following attribute is exported:
 
-* `arn` - Full ARN of the repository.
-* `name` - The name of the repository.
-* `registry_id` - The registry ID where the repository was created.
-* `repository_url` - The URL of the repository (in the form
-    `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
+* `repos` - Map wherein each key/value pair consists of a repo name and URL.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,13 @@
-output "arn" {
-  value = aws_ecr_repository.default.arn
+output "repos" {
+  value = { for r in aws_ecr_repository.default : r.name => r.repository_url }
 }
 
-output "name" {
-  value = aws_ecr_repository.default.name
+# Debug outputs.
+
+output "_actions" {
+  value = (var._debug) ? local.actions : null
 }
 
-output "registry_id" {
-  value = aws_ecr_repository.default.registry_id
-}
-
-output "repository_url" {
-  value = aws_ecr_repository.default.repository_url
+output "_identifiers" {
+  value = (var._debug) ? local.identifiers : null
 }

--- a/policy.tf
+++ b/policy.tf
@@ -1,64 +1,28 @@
+locals {
+  actions_read = [
+    "ecr:BatchCheckLayerAvailability",
+    "ecr:BatchGetImage",
+    "ecr:GetDownloadUrlForLayer",
+  ]
+  actions_write = [
+    "ecr:BatchCheckLayerAvailability",
+    "ecr:CompleteLayerUpload",
+    "ecr:GetDownloadUrlForLayer",
+    "ecr:InitiateLayerUpload",
+    "ecr:PutImage",
+    "ecr:UploadLayerPart",
+  ]
+}
+
 # https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicyExamples.html#IAM_allow_other_accounts
-data "aws_iam_policy_document" "readers_writers" {
+
+data "aws_iam_policy_document" "default" {
   statement {
     principals {
       type        = "AWS"
-      identifiers = var.writers
+      identifiers = local.identifiers
     }
 
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-    ]
-  }
-
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = var.readers
-    }
-
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "readers" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = var.readers
-    }
-
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "writers" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = var.writers
-    }
-
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-    ]
+    actions = local.actions
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,11 @@
-variable "name" {
-  description = "Name of repository."
-}
-
 variable "disable_lifecycle_policy" {
-  description = "If set to 'true', no lifecycle policy is applied."
+  description = "If true, no lifecycle policy is applied."
   default     = false
 }
 
 variable "lifecycle_policy_path" {
   description = "Path to JSON document containing lifecycle policy."
-  default     = ""
+  default     = null
 }
 
 variable "readers" {
@@ -18,14 +14,27 @@ variable "readers" {
   default     = []
 }
 
-variable "writers" {
-  description = "List of account ARNs that can push images."
+variable "repos" {
+  description = "List of ECR repository names."
   type        = list(string)
-  default     = []
 }
 
 variable "tags" {
   description = "Map of tags for resources where supported"
   type        = map(string)
   default     = {}
+}
+
+variable "writers" {
+  description = "List of account ARNs that can push images."
+  type        = list(string)
+  default     = []
+}
+
+# Debugging.
+
+variable "_debug" {
+  description = "Produce debug output (boolean)"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
*   Many services consist of multiple Docker images, and each must have its own ECR repo. Support management of multiple ECR repos in a single configuration file to avoid having to maintain a hierarchy of multiple directories sharing the same configuration.

*   Reorganize `variables.tf` and `README.md` to alphabetize attribute names.

*   Eliminate multiple-choice `aws_iam_policy_document` data source definitions, thereby eliminating code complexity and redundancy. Instead, build lists of allowed actions and identifiers for the policy document depending on whether readers or writers are defined by caller.

*   As a side-effect of this work, replace subscripted resource objects with keyed resource objects using each repo name, as follows:
    - `aws_ecr_lifecycle_policy.default["foo"]`
    - `aws_ecr_repository.default["foo"]`
    - `aws_ecr_repository_policy.default["foo"]`

*   Simplify outputs by returning repo name and repo ARN as key/value pair.

*   Add `_debug` variable and debug outputs.

*   Update legacy Makefile.