### PR TITLE
Refine ECR repository IAM policy

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 0.12.29
-      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
 #     TODO: This step duplicates work done by the Makefile.
 #     - name: check terraform formatting

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `lifecycle_policy_path` – (Optional) Path to JSON document containing lifecycle policy.
 
-* `readers` - (Optional) List of account ARNs that can pull images.
+* `readers` - (Optional) List of account ARNs that can pull images. These accounts are also granted describe and list access to the corresponding repo(s) and images.
 
 * `repos` - (Required) List of repository names.
 

--- a/policy.tf
+++ b/policy.tf
@@ -2,7 +2,10 @@ locals {
   actions_read = [
     "ecr:BatchCheckLayerAvailability",
     "ecr:BatchGetImage",
+    "ecr:DescribeImages",
+    "ecr:DescribeRepositories",
     "ecr:GetDownloadUrlForLayer",
+    "ecr:ListImages",
   ]
   actions_write = [
     "ecr:BatchCheckLayerAvailability",

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "lifecycle_policy_path" {
 }
 
 variable "readers" {
-  description = "List of account ARNs that can pull images."
+  description = "List of account ARNs that can pull images. These accounts are also granted describe and list access to the corresponding repo(s) and images."
   type        = list(string)
   default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Allow reader accounts access to the following actions:

*   ecr:DescribeImages
*   ecr:DescribeRepositories
*   ecr:ListImages

Also update README.md, variables.tf, and versions.tf.

This change will allow users on the development and test accounts to view ECR repos and images that reside on the production account without having production credentials.

I do not believe this capability is available through the AWS console, but it is available through the AWS CLI and API.