### PR TITLE
Support pulling ECR images by lambda functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Example Usage
 module "foo" {
   source = "git@github.com:techservicesillinois/terraform-aws-ecr"
 
+  lambda_arns = ["arn:aws:lambda:us-east-1: 874445906176:function:*"]
   repos = [
     "repo_name_1",
     "repo_name_2",
   ]
-  writers = ["arn:aws:iam::874445906176:root"]
+  readers = ["arn:aws:iam::874445906176:root"]
 }
 ```
 
@@ -29,6 +30,8 @@ Argument Reference
 The following arguments are supported:
 
 * `disable_lifecycle_policy` - (Optional) If set to 'true', no lifecycle policy is applied. Default is 'false'.
+
+* `lambda_arns` – (Optional) List of lambda function ARNs that can pull images at launch.
 
 * `lifecycle_policy_path` – (Optional) Path to JSON document containing lifecycle policy.
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "disable_lifecycle_policy" {
   default     = false
 }
 
+variable "lambda_arns" {
+  description = "List of lambda ARNs that can pull images."
+  type        = list(string)
+  default     = []
+}
+
 variable "lifecycle_policy_path" {
   description = "Path to JSON document containing lifecycle policy."
   default     = null


### PR DESCRIPTION
*   Add policy statement to support pulling ECR images by lambda functions which are deployed from Docker images. The variable lambda_arns supports a list of ARN strings of any accounts and lambda function names that are granted permission to pull Docker images from the specified ECR repo.

*   Statement IDs (SIDs) are added to the policy statements to document their purpose.